### PR TITLE
심자 학습계획이 길면 짤리는 오류 수정

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -7,12 +7,12 @@
         <deviceKey>
           <Key>
             <type value="VIRTUAL_DEVICE_PATH" />
-            <value value="C:\Users\DGSW\.android\avd\Pixel_6_API_32.avd" />
+            <value value="$USER_HOME$/.android/avd/S23_API_33.avd" />
           </Key>
         </deviceKey>
       </Target>
     </targetSelectedWithDropDown>
-    <timeTargetWasSelectedWithDropDown value="2023-03-17T03:24:02.532520Z" />
+    <timeTargetWasSelectedWithDropDown value="2023-06-26T10:44:27.864996Z" />
     <runningDeviceTargetsSelectedWithDialog>
       <Target>
         <type value="RUNNING_DEVICE_TARGET" />

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="1.8.0-release" />
+    <option name="version" value="1.7.10" />
   </component>
 </project>

--- a/presentation/src/main/java/kr/hs/dgsw/smartschool/dodamdodam_teacher/features/night_study/screen/NightStudyScreen.kt
+++ b/presentation/src/main/java/kr/hs/dgsw/smartschool/dodamdodam_teacher/features/night_study/screen/NightStudyScreen.kt
@@ -2,8 +2,6 @@ package kr.hs.dgsw.smartschool.dodamdodam_teacher.features.night_study.screen
 
 import android.util.Log
 import androidx.compose.foundation.background
-import androidx.compose.foundation.gestures.scrollable
-import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column

--- a/presentation/src/main/java/kr/hs/dgsw/smartschool/dodamdodam_teacher/features/night_study/screen/NightStudyScreen.kt
+++ b/presentation/src/main/java/kr/hs/dgsw/smartschool/dodamdodam_teacher/features/night_study/screen/NightStudyScreen.kt
@@ -2,6 +2,8 @@ package kr.hs.dgsw.smartschool.dodamdodam_teacher.features.night_study.screen
 
 import android.util.Log
 import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.scrollable
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -12,6 +14,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.pullrefresh.PullRefreshIndicator
 import androidx.compose.material.pullrefresh.pullRefresh
@@ -54,6 +58,8 @@ fun NightStudyScreen(
 ) {
     val state = nightStudyViewModel.collectAsState().value
     val context = LocalContext.current
+
+    val promptScrollState = rememberScrollState()
 
     nightStudyViewModel.collectSideEffect {
         when (it) {
@@ -98,6 +104,7 @@ fun NightStudyScreen(
         if (state.showPrompt) {
             state.currentSelectedNightStudy?.let {
                 DodamPrompt(
+                    modifier = Modifier.verticalScroll(promptScrollState),
                     title = "${it.student.name}님의 심자 정보",
                     primaryButton = {
                         DodamMediumRoundedButton(


### PR DESCRIPTION
## 개요 
심자 승인 시 학습계획이 너무 길면 스크롤이 되지 않고 짤리는 오류를 스크롤이 가능하게 만들어서 해결할 계획입니다.

## 작업 사항
* prompt에 scrollState를 추가하여 스크롤을 가능하게 만들었습니다.