### PR TITLE
심자 학습계획이 길면 짤리는 오류 수정

### DIFF
--- a/buildSrc/src/main/java/ProjectProperties.kt
+++ b/buildSrc/src/main/java/ProjectProperties.kt
@@ -1,8 +1,8 @@
 import org.gradle.api.JavaVersion
 
 object ProjectProperties {
-    const val VERSION_CODE = 28
-    const val VERSION_NAME = "2.1.0"
+    const val VERSION_CODE = 29
+    const val VERSION_NAME = "2.1.1"
 
     const val APPLICATION_ID = "kr.hs.dgsw.smartschool.dodamdodam_teacher"
     const val NAME_SPACE_DOMAIN = "kr.hs.dgsw.smartschool.domain"


### PR DESCRIPTION
## 개요
심자 승인 시 학습계획이 너무 길면 스크롤이 되지 않고 짤리는 오류를 스크롤이 가능하게 만들어서 해결할 계획입니다.

## 작업 사항
* prompt에 scrollState를 추가하여 스크롤을 가능하게 만들었습니다.
* 버전 코드 28 -> 29
* 버전 2.1.0 -> 2.1.1