### PR TITLE
학교 상벌점 부여시 기숙사 상벌점 부여 사유가 뜨는 오류 수정

### DIFF
--- a/buildSrc/src/main/java/ProjectProperties.kt
+++ b/buildSrc/src/main/java/ProjectProperties.kt
@@ -1,8 +1,8 @@
 import org.gradle.api.JavaVersion
 
 object ProjectProperties {
-    const val VERSION_CODE = 29
-    const val VERSION_NAME = "2.1.1"
+    const val VERSION_CODE = 30
+    const val VERSION_NAME = "2.1.2"
 
     const val APPLICATION_ID = "kr.hs.dgsw.smartschool.dodamdodam_teacher"
     const val NAME_SPACE_DOMAIN = "kr.hs.dgsw.smartschool.domain"


### PR DESCRIPTION
## 문제 상황
상벌점 부여시 학교 상벌점을 부여하려고 들어가도 기숙사 상벌점 부여 사유가 뜨는 오류가 있었습니다.
## 원인
서버에서 상벌점 사유를 학교, 기숙사 가리지 않고 전부 받아 한번에 표시하여서
## 해결 방안
서버에서 받은 PointReason 중 place를 기준으로 if문을 작성하여 해결
## 작업 내용
기숙사 상벌점 부과시 기숙사 상벌점 부과 사유만 나오고 학교 상벌점 부과시 학교 상벌점 부과 사유만 표시하기